### PR TITLE
new methods for outliers

### DIFF
--- a/04_testing/max_pin_adjustment.R
+++ b/04_testing/max_pin_adjustment.R
@@ -44,7 +44,7 @@ df_sectors <- read_csv(
 
 df_msna <- read_csv(
   file.path(
-    dirname(getwd()),
+    file_paths$agg_dir,
     "MSNA_data.csv"
   )
 ) %>%


### PR DESCRIPTION
two new ways of flagging outliers:
For the first, flagging outliers that are notably smaller or larger than the rest of outliers, looking at the difference in PiN (as % of affection population) between highest and second highest in all lowest unit of disaggregation for each country and calculate outliers from the % of difference.

The second one is looking at all sectoral PiNs of lowest unit of disaggregations within each admin 1 and calculate which one of the PiNs (as % of affection population) are upper or lower outliers. 